### PR TITLE
Cleanup files after request

### DIFF
--- a/src/pdfhook/views.py
+++ b/src/pdfhook/views.py
@@ -1,5 +1,5 @@
 from flask import request, render_template, jsonify, Response, url_for
-import io, os
+import io, os, glob
 from src.main import db
 from src.pdfhook import (
     blueprint,
@@ -10,6 +10,12 @@ from src.pdfhook import (
 
 
 pdf_serializer = serializers.PDFFormSerializer()
+
+@blueprint.after_request
+def cleanup_files(response):
+    [os.remove(filename) for filename in glob.glob('./data/tmp*')]
+    [os.remove(filename) for filename in glob.glob('./data/filled*')]
+    return response
 
 @blueprint.route('/', methods=['POST'])
 def post_pdf():

--- a/tests/integration/test_sample_pdfhook.py
+++ b/tests/integration/test_sample_pdfhook.py
@@ -3,6 +3,7 @@ from pprint import pprint
 from flask import url_for
 import requests
 import json
+import glob
 from tests.test_base import BaseTestCase
 
 
@@ -55,6 +56,9 @@ class TestPDFHook(BaseTestCase):
             results.pop('added_on')
             self.maxDiff = None
             self.assertDictEqual(results, results_sample)
+            self.assertEqual(glob.glob('data/tmp*'), [])
+            self.assertEqual(glob.glob('data/filled*'), [])
+
 
     def test_fill_pdf(self):
         # TODO: Setting checkboxes still doesn't do anything
@@ -84,5 +88,6 @@ class TestPDFHook(BaseTestCase):
         results = response.data.decode('utf-8')
         self.assertIn('filled', results)
         self.assertIn('.pdf', results)
-
+        self.assertEqual(glob.glob('data/tmp*'), [])
+        self.assertEqual(glob.glob('data/filled*'), [])
 


### PR DESCRIPTION
Removes all `tmp` and `filled` files
