### PR TITLE
Make checkboxes work

### DIFF
--- a/src/pdfhook/tasks.py
+++ b/src/pdfhook/tasks.py
@@ -112,7 +112,7 @@ def fill_fdf(fdf_str, mapping, data):
             elif field['type'] == 'Button':
                 span = field['value_template_span']
                 start = span[0] + 1
-                end = span[1] - 1
+                end = span[1]
                 if end < start:
                     end = start
                 value = data[key]

--- a/tests/integration/test_sample_pdfhook.py
+++ b/tests/integration/test_sample_pdfhook.py
@@ -45,7 +45,6 @@ class TestPDFHook(BaseTestCase):
                 data={'file':f}
                 )
             results = json.loads(response.data.decode('utf-8'))
-            print(results)
             self.assertIn('id', results)
             self.assertEqual(
                 results['url'], url_for(


### PR DESCRIPTION
Setting checkboxes didn't work because the value span was cutting off one character

For text, the regex captures something like `(Value)` so `[start+1:end-1]` makes sense.
For buttons, the regex captures `/Off` so it needs to be `[start+1:end]` otherwise you end up writing the value `Yesf` to the form with fails.

Also clean up a stray print I left in
