### PR TITLE
Demo upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TEST_SCOPE=tests/
+
 install:
 	pip install -r requirements.txt
 
@@ -5,7 +7,7 @@ run:
 	honcho start local
 
 test:
-	nosetests tests/ \
+	nosetests $(TEST_SCOPE) \
 		--verbose \
 		--nocapture \
 		--with-coverage \

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,4 @@
 import os
-from flask_migrate import MigrateCommand
 from flask_script import Manager, Shell, Server
 from src.main import create_app, db
 
@@ -15,7 +14,6 @@ def _make_context():
 
 manager.add_command('server', Server(port=os.environ.get('PORT', 9000)))
 manager.add_command('shell', Shell(make_context=_make_context))
-manager.add_command('db', MigrateCommand)
 
 
 if __name__ == '__main__':

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,7 +5,6 @@ Flask==0.10.1
 
 # database
 SQLAlchemy==1.0.12
-Flask-Migrate==1.8.0
 
 # serialization
 flask-marshmallow==0.6.2
@@ -13,6 +12,7 @@ marshmallow-sqlalchemy==0.8.1
 
 # Utilities
 python-slugify==1.2.0
+Flask-Script==2.0.5
 
 # Server
 honcho==0.6.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,6 +5,7 @@ Flask==0.10.1
 
 # database
 SQLAlchemy==1.0.12
+Flask-SQLAlchemy==2.1
 
 # serialization
 flask-marshmallow==0.6.2

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -3,6 +3,3 @@ db = SQLAlchemy()
 
 from flask_marshmallow import Marshmallow
 ma = Marshmallow()
-
-from flask_migrate import Migrate
-migrate = Migrate()

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 
 import os
 from flask import Flask
-from src.extensions import db, ma, migrate
+from src.extensions import db, ma
 from src.context_processors import inject_static_url
 from src.logs import register_logging
 from src.pdfhook import blueprint
@@ -23,7 +23,6 @@ def create_app():
 
 def register_extensions(app):
     db.init_app(app)
-    migrate.init_app(app, db)
     ma.init_app(app)
 
 def register_blueprints(app):

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,10 +3,12 @@ import os
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 PROJECT_ROOT = os.path.abspath(os.path.join(HERE, os.pardir))
+DEFAULT_DATABASE_PATH = 'sqlite:///' + os.path.join(PROJECT_ROOT, 'data', 'default.db')
+DEFAULT_TEST_DATABASE_PATH = 'sqlite:///' + os.path.join(PROJECT_ROOT, 'data', 'test_default.db')
 
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY', 'secret-key')
-    SQLITE_DATABASE_URI = os.environ.get('DATABASE_URL', 'default.db')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', DEFAULT_DATABASE_PATH)
     SERVER_NAME = os.environ.get('HOST_NAME', 'localhost:5000')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
@@ -23,10 +25,6 @@ class DevConfig(Config):
 
 
 class TestConfig(Config):
-    SQLITE_DATABASE_URI = os.environ.get('TEST_DATABASE_URL', 'default.db')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL', DEFAULT_TEST_DATABASE_PATH)
     TESTING = True
     DEBUG = True
-    # For: `nose.proxy.AssertionError: Popped wrong request context.`
-    # http://stackoverflow.com/a/28139033/399726
-    # https://github.com/jarus/flask-testing/issues/21
-    PRESERVE_CONTEXT_ON_EXCEPTION = False


### PR DESCRIPTION
The purpose of this PR is to ensure that the demo page can upload pdfs out of the box, for #8

Changes:
- Removes Flask-Migrate. This app has literally one table and is still an early prototype. Database migration seems like overkill.
- with `make test` you can supply an optional scope, for example
  
  ```
  make test TEST_SCOPE=tests.integration.test_sample_pdfhook
  ```
- in `settings.py` we now use the sqlalchemy-specific setting, `SQLALCHEMY_DATABASE_URI`
- paths for sqlite database are all absolute paths
- the test database is separated from the default database
- on the first request, if the table doesn't exist, it will create tables in the database
