### PR TITLE
Remove pdftk, update heroku deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,6 @@ To redeploy on Heroku:
     heroku login
     heroku apps:create
     git push heroku master
-    # heroku addons:create heroku-postgresql:hobby-dev
-    # heroku buildpacks:set heroku/python
-    # heroku buildpacks:add --index 1 https://github.com/fxtentacle/heroku-pdftk-buildpack
-    # heroku config:set LD_LIBRARY_PATH=/app/bin
-    # heroku config:set PDFTK_PATH=/app/bin/pdftk
-    # heroku config:set CONFIG=src.settings.ProdConfig
-    # git push heroku master
 
 To deploy on Cloud Foundry:
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,8 @@ The following instructions assume:
 
 This is a [Python 3](https://docs.python.org/3/) app written using [Flask](http://flask.pocoo.org/). It has only been tested on Ubuntu 14.04 (via Travis CI) and OS X 10.11
 
-This application depends on a command line utility called [`pdftk` server](https://www.pdflabs.com/docs/pdftk-man-page/),  by [PDF Labs](https://www.pdflabs.com/), offered under a [GPL License](https://www.pdflabs.com/docs/pdftk-license/).
+This application depends on the [`itextpdf`](https://github.com/itext/itextpdf) java library, by [iText](http://itextpdf.com/), offered under [GNU AGPL version 3](https://github.com/itext/itextpdf/blob/master/LICENSE.md).
 
-### Installation
-
-If you are running OS X El Capitan 10.11, download the pdftk server installer here (requires your password for installation):
-https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg
 
 #### Install Python 3.4 or 3.5
 
@@ -96,14 +92,18 @@ Visit [http://localhost:5000/](http://localhost:5000/) to see the demo page. Use
 
 To redeploy on Heroku:
 
+    git clone https://www.github/codeforamerica/pdfhook.git
+    cd pdfhook
+    heroku login
     heroku apps:create
-    heroku addons:create heroku-postgresql:hobby-dev
-    heroku buildpacks:set heroku/python
-    heroku buildpacks:add --index 1 https://github.com/fxtentacle/heroku-pdftk-buildpack
-    heroku config:set LD_LIBRARY_PATH=/app/bin
-    heroku config:set PDFTK_PATH=/app/bin/pdftk
-    heroku config:set CONFIG=src.settings.ProdConfig
     git push heroku master
+    # heroku addons:create heroku-postgresql:hobby-dev
+    # heroku buildpacks:set heroku/python
+    # heroku buildpacks:add --index 1 https://github.com/fxtentacle/heroku-pdftk-buildpack
+    # heroku config:set LD_LIBRARY_PATH=/app/bin
+    # heroku config:set PDFTK_PATH=/app/bin/pdftk
+    # heroku config:set CONFIG=src.settings.ProdConfig
+    # git push heroku master
 
 To deploy on Cloud Foundry:
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,6 +5,7 @@ Flask==0.10.1
 # database
 SQLAlchemy==1.0.12
 Flask-SQLAlchemy==2.1
+psycopg2==2.6.1
 
 # serialization
 flask-marshmallow==0.6.2
@@ -14,4 +15,3 @@ marshmallow-sqlalchemy==0.8.1
 Flask-Script==2.0.5
 honcho==0.6.6
 Flask-SSLify==0.1.5
-


### PR DESCRIPTION
Replaced pdftk references with itextpdf. Simplified heroku deployment.
